### PR TITLE
lora/qlora training w/wo unsloth on NVIDIA L4 (20GB VRAM usage)

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,5 +1,5 @@
 dataset_id: "ariG23498/license-detection-paligemma"
-model_id: "unsloth/gemma-3-4b-it" #"google/gemma-3-4b-pt"
+model_id: "google/gemma-3-4b-pt" # "unsloth/gemma-3-4b-it" 
 checkpoint_id: "ajaymin28/Gemma3_ObjeDet"
 
 device: "cuda"

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,5 +1,5 @@
 dataset_id: "ariG23498/license-detection-paligemma"
-model_id: "google/gemma-3-4b-pt"
+model_id: "unsloth/gemma-3-4b-it" #"google/gemma-3-4b-pt"
 checkpoint_id: "ajaymin28/Gemma3_ObjeDet"
 
 device: "cuda"
@@ -8,13 +8,18 @@ dtype: "bfloat16"
 batch_size: 16
 learning_rate: 2e-5
 epochs: 1
+max_step_to_train: 100
+validate_steps_freq: 10
 
 finetune_method: "qlora"   # FFT | lora | qlora
 use_unsloth: false
 
 
-mm_tunable_parts: # Only for the FFT 
-  - multi_modal_projector
-  - vision_tower
-  - language_model
-project_name:  "Gemma3_LoRA"
+mm_tunable_parts:
+  - no_exist_layer   # basically not finetuning any base components
+  # - mlp
+  # - multi_modal_projector
+  # - vision_tower
+  # - language_model
+wandb_project_name:  "Gemma3_LoRA"
+push_model_to_hub: true

--- a/configs/lora_config.yaml
+++ b/configs/lora_config.yaml
@@ -10,3 +10,5 @@ target_modules:
   - down_proj
   - gate_proj
 max_seq_length: 2048  # Unsloth will RoPE-scale
+load_in_4bit: true
+load_in_8bit: false

--- a/configs/qlora_config.yaml
+++ b/configs/qlora_config.yaml
@@ -11,7 +11,10 @@ target_modules:
   - gate_proj
 max_seq_length: 2048  # Unsloth will RoPE-scale
 
-# LoRA-specific: no quantization
-load_in_4bit: false
+# QLoRA-specific: quantization enabled
+load_in_4bit: true
 load_in_8bit: false
-quantization_config: null
+quantization_config:
+  bnb_4bit_use_double_quant: true
+  bnb_4bit_quant_type: "nf4"
+  bnb_4bit_compute_dtype: "bfloat16"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,6 @@ wandb
 peft
 albumentations
 argparse
+omegaconf
+unsloth==2025.5.7 
+unsloth-zoo==2025.5.8

--- a/train.py
+++ b/train.py
@@ -8,10 +8,10 @@ logger = logging.getLogger(__name__)
 
 FastModel = None
 # Optional – comment below imports if you are not planinng to use unsloth
-try: from unsloth import FastModel
-except ImportError as e: logger.log(f"Unsloth import error : {e}")
-except NotImplementedError as e: logger.log(f"Unsloth NotImplementedError error : {e}")
-    
+# try: from unsloth import FastModel
+# except ImportError as e: logger.warning(f"Unsloth import error : {e}")
+# except NotImplementedError as e: logger.warning(f"Unsloth NotImplementedError error : {e}")
+
 
 import wandb
 from functools import partial
@@ -26,6 +26,7 @@ from utils.config import Configuration
 from utils.utilities import train_collate_function, train_collate_function_unsloth
 from utils.utilities import save_best_model, push_to_hub, load_saved_model
 from peft import get_peft_config, get_peft_model, LoraConfig
+from peft import prepare_model_for_kbit_training
 import albumentations as A
 
 
@@ -55,15 +56,15 @@ augmentations = A.Compose([
 #     )
 #     return train_dataloader
 
-def get_dataloader(processor, args, dtype, split="train", is_unsloth=False):
-    logger.info("Fetching the dataset")
+def get_dataloader(args:Configuration,processor=None,tokenizer=None, split="train", is_unsloth=False):
+    logger.info(f"Fetching the dataset: {cfg.dataset_id}:{split}")
     train_dataset = load_dataset(cfg.dataset_id, split=split)
 
     if is_unsloth:
         # <- Use the Unsloth tokenizer instead of processor
-        train_collate_fn = partial(train_collate_function_unsloth,tokenizer=tokenizer,dtype=dtype,transform=augmentations)
+        train_collate_fn = partial(train_collate_function_unsloth,tokenizer=tokenizer,dtype=args.dtype,transform=augmentations)
     else:
-        train_collate_fn = partial(train_collate_function, processor=processor, dtype=dtype, transform=augmentations)
+        train_collate_fn = partial(train_collate_function, processor=processor, dtype=args.dtype, transform=augmentations)
 
     logger.info("Building data loader")
     train_dataloader = DataLoader(
@@ -98,13 +99,14 @@ def step(model, batch, device, use_fp16, optimizer=None, scaler=None):
 
 def validate_all(model, val_loader, cfg, use_fp16,val_batches=5):
 
-    if cfg.use_unsloth and FastModel is not None:
-        FastModel.for_inference(model) # Enable for inference!
-    else:
-        model.eval()
+    # if cfg.use_unsloth and FastModel is not None:
+    #     FastModel.for_inference(model) # Enable for inference!
+    # else:
+    #     model.eval()
+    model.eval()
 
     with torch.no_grad():
-        if val_batches:
+        if val_batches>0:
             ## TODO: This logic is Temp and should be removed in final clean up
             n_batches = val_batches
             losses = []
@@ -117,27 +119,121 @@ def validate_all(model, val_loader, cfg, use_fp16,val_batches=5):
     model.train()
     return sum(losses) / len(losses) if len(losses)> 0 else 0
 
+import psutil
+import os
+
+def memory_stats(get_dict=False, print_mem_usage=True, device=None):
+    stats = {
+            "cpu": "",
+            "ram": "",
+            "cuda_free": "",
+            "cuda_total": "",
+            "cuda_allocated": "",
+            "cuda_reserved": "",
+            "peak_vram_allocated_mb": "",
+    }
+
+    cuda_freeMem = 0
+    cuda_total = 0
+    cuda_allocated = 0
+    cuda_reserved = 0
+    peak_vram_allocated_bytes = 0
+    peak_vram_allocated_mb = 0
+    
+    if torch.cuda.is_available():
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        
+        try:
+            cuda_freeMem, cuda_total  = torch.cuda.mem_get_info()
+            cuda_total = cuda_total/1024**2
+            cuda_freeMem = cuda_freeMem/1024**2
+        except: pass
+            
+        try:
+            cuda_allocated = torch.cuda.memory_allocated()/1024**2
+            cuda_reserved = torch.cuda.memory_reserved()/1024**2
+        except: pass
+
+        try:
+            peak_vram_allocated_bytes = torch.cuda.max_memory_allocated(device)
+            peak_vram_allocated_mb = peak_vram_allocated_bytes / (1024 ** 2)
+        except: pass
+
+        stats["cuda_free"] = cuda_freeMem
+        stats["cuda_total"] = cuda_total
+        stats["cuda_allocated"] = round(cuda_allocated,3)
+        stats["cuda_reserved"] = round(cuda_reserved,3)
+        stats["peak_vram_allocated_mb"] = round(peak_vram_allocated_mb,3)
+
+    process = psutil.Process(os.getpid())
+    ram_mem_perc = process.memory_percent()
+    cpu_usage = psutil.cpu_percent()
+
+    stats["cpu"] = cpu_usage
+    stats["ram"] = ram_mem_perc
+
+    if print_mem_usage:
+        logger.info(f"CPU: {cpu_usage:.2f}% RAM: {ram_mem_perc:.2f}% GPU memory Total: [{cuda_total:.2f}] Available: [{cuda_freeMem:.2f}]  Allocated: [{cuda_allocated:.2f}] Reserved: [{cuda_reserved:.2f}] Cuda Peak Mem: {peak_vram_allocated_mb:.2f}")
+
+    if get_dict:
+        return stats
+
 def train_model(model, optimizer, cfg:Configuration, train_loader, val_loader=None):
+
+    memory_stats()
+    torch.cuda.empty_cache() # TODO: Do I need this? Just want to make sure I have mem cleaned up before training starts.
+    logger.info(f"called: torch.cuda.empty_cache()")
+    memory_stats()
     use_fp16 = cfg.dtype in [torch.float16, torch.bfloat16]
     scaler = GradScaler() if use_fp16 else None
     global_step, best_val_loss = 0, float("inf")
 
-    if cfg.use_unsloth and FastModel is not None:
-        FastModel.for_training(model) # Enable for inference!
-    else:
-        model.train()
-        model.to(cfg.device)
+    # total_trainable = 0
+    # total_params = 0
+    # for n, p in model.named_parameters():
+    #     total_params += p.numel()
+    #     if p.requires_grad:
+    #         total_trainable += p.numel()
+    # logger.info(f"Total trainable parameters before train(): {total_trainable:,}")
+
+    # if cfg.use_unsloth and FastModel is not None:
+    #     # logger.info("Before setting for training...")
+    #     # model.print_trainable_parameters()
+    #     FastModel.for_training(model, use_gradient_checkpointing=True) # Enable for training!  # TODO :calling this method uses so much memory, investigate
+    # else:
+    #     model.train()
+    #     model.to(cfg.device)
+
+    model.train()
+    model.to(cfg.device)
+
+    # total_trainable = 0
+    # total_params = 0
+    # for n, p in model.named_parameters():
+    #     total_params += p.numel()
+    #     if p.requires_grad:
+    #         total_trainable += p.numel()
+    # logger.info(f"Total trainable parameters after train(): {total_trainable:,}")
+
+    logger.info("after setting for training...")
+    # model.print_trainable_parameters()
+
 
     for epoch in range(cfg.epochs):
         for idx, batch in enumerate(train_loader):
+
+            torch.cuda.reset_peak_memory_stats(cfg.device) 
+            torch.cuda.empty_cache()
+
             loss = step(model, batch, cfg.device, use_fp16, optimizer, scaler)
             if global_step % 1 == 0:
                 logger.info(f"Epoch:{epoch} Step:{global_step} Loss:{loss:.4f}")
-                wandb.log({"train/loss": loss, "epoch": epoch}, step=global_step)
+                # wandb.log({"train/loss": loss, "epoch": epoch}, step=global_step)
             if val_loader and global_step % cfg.validate_steps_freq == 0:
-                val_loss = validate_all(model, val_loader, cfg, use_fp16, val_batches=5) # TODO, disable val_batches in final commit/run
+                val_loss = validate_all(model, val_loader, cfg, use_fp16, val_batches=1) # if val_batches>0 the code will validate on that many batches only. -1 to disable this
                 logger.info(f"Step:{global_step} Val Loss:{val_loss:.4f}")
-                wandb.log({"val/loss": val_loss, "epoch": epoch}, step=global_step)
+                # wandb.log({"val/loss": val_loss, "epoch": epoch}, step=global_step)
 
             if val_loss < best_val_loss:
                 best_val_loss = val_loss
@@ -147,6 +243,11 @@ def train_model(model, optimizer, cfg:Configuration, train_loader, val_loader=No
             if global_step>cfg.max_step_to_train-1 and cfg.max_step_to_train>0:
                 break
             global_step += 1
+            if global_step % 5 == 0:
+                memory_stats()
+            
+            if global_step % 5 == 0:
+                memory_stats()
 
     return model
 
@@ -180,10 +281,9 @@ def load_model(cfg:Configuration):
                 lora_alpha=lcfg.alpha, # Recommended alpha == r at least
                 lora_dropout=lcfg.dropout,
                 bias = "none",
-                random_state = 3407,
+                random_state = 3407
+                # TODO add rs_lora and dora
             )
-
-            model.print_trainable_parameters()
 
 
     else:
@@ -193,7 +293,7 @@ def load_model(cfg:Configuration):
             bnb_config = BitsAndBytesConfig(
                 load_in_4bit=True,
                 bnb_4bit_use_double_quant=True,
-                bnb_4bit_quant_type="fp4",
+                bnb_4bit_quant_type="nf4",
                 bnb_4bit_compute_dtype=cfg.dtype,
             )
             quant_args = {"quantization_config": bnb_config, "device_map": "auto"}
@@ -205,7 +305,12 @@ def load_model(cfg:Configuration):
             **quant_args,
         )
 
+
         if cfg.finetune_method in {"lora", "qlora"}:
+
+            if cfg.finetune_method=="qlora":
+                model = prepare_model_for_kbit_training(model)
+
 
             lora_cfg = LoraConfig(
                 r=lcfg.r,
@@ -213,11 +318,15 @@ def load_model(cfg:Configuration):
                 target_modules=lcfg.target_modules,
                 lora_dropout=lcfg.dropout,
                 bias="none",
+                use_dora=True if cfg.finetune_method=="qlora" else False,
+                use_rslora=True # Rank-Stabilized LoRA  --> `lora_alpha/math.sqrt(r)`
             )
             
             model = get_peft_model(model, lora_cfg)
-            model.print_trainable_parameters()
+            memory_stats()
             torch.cuda.empty_cache() # TODO: Do I need this? Just want to make sure I have mem cleaned up before training starts.
+            logger.info(f"called: torch.cuda.empty_cache()")
+            memory_stats()
 
         elif cfg.finetune_method == "FFT":
             # handled below before printing params
@@ -226,10 +335,13 @@ def load_model(cfg:Configuration):
             raise ValueError(f"Unknown finetune_method: {cfg.finetune_method}")
     
     for n, p in model.named_parameters():
-        if cfg.finetune_method == "FFT":
+        if cfg.finetune_method == "FFT": # TODO: should FFT finetune all components? or just some, change FFT name to just FT?
             p.requires_grad = any(part in n for part in cfg.mm_tunable_parts)
         if p.requires_grad:
             print(f"{n} will be finetuned")
+    
+    if cfg.finetune_method in {"lora", "qlora"}:
+        model.print_trainable_parameters()
 
     return model, tokenizer
 
@@ -245,23 +357,23 @@ if __name__ == "__main__":
 
     # 3. Get Data
     if cfg.use_unsloth:
-        train_dataloader = get_dataloader(tokenizer=tokenizer, args=cfg, dtype=cfg.dtype,split="train",is_unsloth=True)
-        validation_dataloader = get_dataloader(tokenizer=tokenizer, args=cfg, dtype=cfg.dtype, split="validation",is_unsloth=True)
+        train_dataloader = get_dataloader(args=cfg,tokenizer=tokenizer, split="train",is_unsloth=True)
+        validation_dataloader = get_dataloader(args=cfg,tokenizer=tokenizer, split="validation",is_unsloth=True)
     else:
         processor = AutoProcessor.from_pretrained(cfg.model_id)
-        train_dataloader = get_dataloader(processor=processor, args=cfg, dtype=cfg.dtype, split="train")
-        validation_dataloader = get_dataloader(processor=processor, args=cfg, dtype=cfg.dtype, split="validation")
+        train_dataloader = get_dataloader(args=cfg, processor=processor, split="train")
+        validation_dataloader = get_dataloader(args=cfg, processor=processor, split="validation")
     
     # Credits to Sayak Paul for this beautiful expression
     params_to_train = list(filter(lambda x: x.requires_grad, model.parameters()))
     optimizer = torch.optim.AdamW(params_to_train, lr=cfg.learning_rate)
 
-    # 5. Enable logging, need to login or set wanddb token in os.env
-    wandb.init(
-        project=cfg.wandb_project_name,
-        name=cfg.run_name if hasattr(cfg, "run_name") else None,
-        config=vars(cfg),
-    )
+    # # 5. Enable logging, need to login or set wanddb token in os.env
+    # wandb.init(
+    #     project=cfg.wandb_project_name,
+    #     name=cfg.run_name if hasattr(cfg, "run_name") else None,
+    #     config=vars(cfg),
+    # )
 
     # 5. Actual train and validation, validation_dataloader=None to do just traing.
     train_model(model, optimizer, cfg, train_dataloader, validation_dataloader)
@@ -276,5 +388,5 @@ if __name__ == "__main__":
     
     
     # 8. Wrap up
-    wandb.finish()
+    # wandb.finish()
     logger.info("Train finished")

--- a/utils/config.py
+++ b/utils/config.py
@@ -29,7 +29,7 @@ class UserLoRAConfig:
 @dataclass
 class Configuration:
     dataset_id: str = "ariG23498/license-detection-paligemma"
-    model_id: str = "unsloth/gemma-3-4b-it" #"google/gemma-3-4b-pt"
+    model_id: str = "google/gemma-3-4b-pt" # "unsloth/gemma-3-4b-it"
     checkpoint_id: str = "ajaymin28/Gemma3_ObjeDet"
     push_model_to_hub: bool = False
     device: str = "cuda" if torch.cuda.is_available() else "cpu"

--- a/utils/config.py
+++ b/utils/config.py
@@ -14,7 +14,7 @@ def str2bool(v):
 @dataclass
 class UserLoRAConfig:
     r: int = 32
-    alpha: int = 64
+    alpha: int = 32
     dropout: float = 0.05
     target_modules: List[str] = field(default_factory=lambda: [
         "q_proj", "k_proj", "v_proj", "o_proj",
@@ -29,17 +29,17 @@ class UserLoRAConfig:
 @dataclass
 class Configuration:
     dataset_id: str = "ariG23498/license-detection-paligemma"
-    model_id: str = "google/gemma-3-4b-pt"
-    checkpoint_id: str = "sergiopaniego/gemma-3-4b-pt-object-detection-aug"
+    model_id: str = "unsloth/gemma-3-4b-it" #"google/gemma-3-4b-pt"
+    checkpoint_id: str = "ajaymin28/Gemma3_ObjeDet"
     push_model_to_hub: bool = False
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
     dtype: torch.dtype = torch.bfloat16
-    validate_steps_freq: int = 500
+    validate_steps_freq: int = 10
     batch_size: int = 16
     learning_rate: float = 2e-5
-    epochs: int = 2
-    max_step_to_train: int = 5000 # if model converges before training one epoch, set to 0 or -1 to disable
-    finetune_method: str = "FFT"  # FFT | lora | qlora
+    epochs: int = 1
+    max_step_to_train: int = 100 # if model converges before training one epoch, set to 0 or -1 to disable
+    finetune_method: str = "lora"  # FFT | lora | qlora
     use_unsloth: bool = False
     mm_tunable_parts: List[str] = field(default_factory=lambda: ["multi_modal_projector"]) # vision_tower,language_model
     lora: UserLoRAConfig = field(default_factory=UserLoRAConfig)
@@ -82,7 +82,7 @@ class Configuration:
         parser.add_argument("--lora.load_in_4bit", type=str2bool,default=cfg_dict["lora"]["load_in_4bit"])
         parser.add_argument("--lora.load_in_8bit", type=str2bool,default=cfg_dict["lora"]["load_in_8bit"])
 
-        parser.add_argument("--wandb_project_name", type=str, default=cfg_dict["project_name"])
+        parser.add_argument("--wandb_project_name", type=str, default=cfg_dict["wandb_project_name"])
 
         args = parser.parse_args()
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -12,7 +12,7 @@ def str2bool(v):
 
 
 @dataclass
-class LoRAConfig:
+class UserLoRAConfig:
     r: int = 32
     alpha: int = 64
     dropout: float = 0.05
@@ -42,13 +42,13 @@ class Configuration:
     finetune_method: str = "FFT"  # FFT | lora | qlora
     use_unsloth: bool = False
     mm_tunable_parts: List[str] = field(default_factory=lambda: ["multi_modal_projector"]) # vision_tower,language_model
-    lora: LoRAConfig = field(default_factory=LoRAConfig)
+    lora: UserLoRAConfig = field(default_factory=UserLoRAConfig)
     wandb_project_name: str = "Gemma3_LoRA"
 
     @classmethod
     def load(cls, main_cfg_path="configs/config.yaml", lora_cfg_path="configs/lora_config.yaml"):
         base_cfg = OmegaConf.load(main_cfg_path)
-        lora_cfg = OmegaConf.load(lora_cfg_path)
+        lora_cfg = OmegaConf.load(lora_cfg_path) # TODO: Merge config into one, refer to hydra config.
         base_cfg.lora = lora_cfg
         return OmegaConf.to_container(base_cfg, resolve=True)
 
@@ -92,7 +92,7 @@ class Configuration:
             "bfloat16": torch.bfloat16,
         }
 
-        lora_config = LoRAConfig(
+        lora_config = UserLoRAConfig(
             r=args.__dict__["lora.r"],
             alpha=args.__dict__["lora.alpha"],
             dropout=args.__dict__["lora.dropout"],
@@ -102,6 +102,7 @@ class Configuration:
             load_in_8bit=args.__dict__["lora.load_in_8bit"],
         )
 
+        # TODO handle this long list, probably migrate to hydra conf.
         return cls(
             dataset_id=args.dataset_id,
             model_id=args.model_id,


### PR DESCRIPTION
# Pull Request Summary

## Summary

- Refactored and modularized the codebase to support extensive configuration(OmegaConf) and future extensions.
- Enhanced argument parsing to convert dataclass configurations to CLI arguments: `dataclass → CLI args → final config`.
- Implemented model checkpointing based on best validation loss and tested Weights & Biases (wandb) logging.
- Added support for pushing the best model checkpoint to the Hugging Face Hub.
- Find wandb report here: https://api.wandb.ai/links/ajaymin28-university-of-central-florida/4kw0i5o2
- Find Weights here: https://huggingface.co/ajaymin28/Gemma3_ObjeDet
- log file:  [unsloth_log_gemma3.log](https://github.com/user-attachments/files/20784915/unsloth_log_gemma3.log)


---

## What Works

- Training and validation using Unsloth, qlora vanilla method.
- Local saving of model checkpoints on best validation loss.
- Loading models from local directories.
- Automatically pushing the best model to Hugging Face Hub.

---

## Common errors and resolutions

While Dataset loading if you get an error "Invalid pattern: '**' can only be an entire path component"
Refer this: https://stackoverflow.com/questions/77671277/valueerror-invalid-pattern-can-only-be-an-entire-path-component

AttributeError: 'Gemma3ModelOutputWithPast' object has no attribute 'loss': https://github.com/unslothai/unsloth/issues/2656


---

## Not Yet Tested

- The saved model checkpoint has **not** been thoroughly tested for inference yet. This is a high-priority task.

---

## Packages
except colab:
> uv pip install -r requirements.txt
> uv pip install unsloth==2025.5.7 unsloth-zoo==2025.5.8 omegaconf

if you are on colab, refer this:  
> https://colab.research.google.com/github/unslothai/notebooks/blob/main/nb/Gemma3_(4B).ipynb

---

## commands used for training with unsloth on L4
In train.py, uncomment unsloth imports then run below command

> python train.py --dtype=bfloat16 --finetune_method=qlora --batch_size=16 --use_unsloth=True --epochs=1 --max_step_to_train=1000 --validate_steps_freq=100

## commands used for training without unsloth on L4
In train.py, comment unsloth imports, make sure FastModel = None, then run below command

> python train.py --dtype=bfloat16 --finetune_method=qlora --batch_size=6 --use_unsloth=False --epochs=1 --max_step_to_train=1000 --validate_steps_freq=100

## loss graphs
![image](https://github.com/user-attachments/assets/efe18ff1-e03b-4713-9a70-2b5807215f3d)


## TODO

1. Test the trained model, publish results. 
2. Train other methods, vanilla lora, vanilla qlora and test those models as well. 
3. clean qlora and lora config and test for all configs (rslora, dora etc.).